### PR TITLE
fr translations: Remove "cross" inside title

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,7 +1,7 @@
 {
-    "ep_delete_after_delay.warning": "× ATTENTION !",
+    "ep_delete_after_delay.warning": "ATTENTION !",
     "ep_delete_after_delay.reload": "Le pad a expiré. La page sera rechargée dans 5 secondes.",
-    "ep_delete_after_delay.close": "× Délai avant suppression",
+    "ep_delete_after_delay.close": "Délai avant suppression",
     "ep_delete_after_delay.days": "Sans nouvelle modification, votre pad sera supprimé dans approximativement XXXX jours.",
     "ep_delete_after_delay.hours": "Sans nouvelle modification, votre pad sera supprimé dans approximativement XXXX heures.",
     "ep_delete_after_delay.minutes": "Sans nouvelle modification, votre pad sera supprimé dans approximativement XXXX minutes.",


### PR DESCRIPTION
Since Etherpad 1.8.3, a cross is already added to the popup